### PR TITLE
Add Advisory 0012 (xz Vulnerability)

### DIFF
--- a/advisories/0012.md
+++ b/advisories/0012.md
@@ -1,0 +1,33 @@
+### Mirantis Container Products and CVE-2024-3094: Not Vulnerable
+
+#### Release Date
+2024-04-16
+
+#### Overview
+This advisory addresses the relevance of CVE-2024-3094, a vulnerability identified within the xz package, and its implications for Mirantis Container Products (MCR, MSR, and MKE). While Mirantis has analyzed the impact of this vulnerability on the container products and found that they are not vulnerable, customers should always consult their Operating System vendor to ensure that the remaining portions of their deployment are also secure.
+
+#### Unaffected Products
+None of MCR (Mirantis Container Runtime), MSR (Mirantis Secure Registry), or MKE (Mirantis Kubernetes Engine) are vulnerable.
+
+As with all deployments, the operating system that hosts the usage of Mirantis container products may be vulnerable. Despite the information below, the host system should always be verified with the operating system vendor to ensure that it is not vulnerable. Though no additional risk is introduced through the use of the Mirantis products listed in this bulletin, taking this step will ensure that the complete deployment is secured.
+
+Mirantis Container Runtime (MCR) is shipped as operating system packages. As such, MCR itself does not contain or enable the installation of any affected versions of xz.
+
+Mirantis Secure Registry (MSR) consists of numerous components that are built on [https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html](Alpine Linux) images.  Mirantis has confirmed that this underlying Alpine image is not affected by the xz vulnerability and therefore MSR provides no vector for attack via this exploit. Customer images stored in a registry hosted by MSR could however contain this vulnerability which should be monitored and remedied using MSR security and CVE scanning features.
+
+Mirantis Kubernetes Engine (MKE) has been verified not to include any vulnerable xz, as either part of the software (like MSR, MKE is also built on unaffected [https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html](Alpine Linux)) or as part of the build chain. Accordingly, the use of MKE does not provide any additional exposure to this xz vulnerability. Customers should additionally ensure that applications deployed using MKE are not vulnerable to secure their environment.
+
+
+#### Vulnerability Information
+
+#### CVE Identifier
+CVE-2024-3094
+
+#### CVSSv3.1
+10.0 (Critical) CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+
+#### Acknowledgements
+Found by Andres Freund.
+#### Disclosure Timeline
+* 2024-03-29: Andres Freund discovers vulnerability
+* 2024-04-02: Mirantis confirms that listed products are unaffected

--- a/advisories/0012.md
+++ b/advisories/0012.md
@@ -11,14 +11,14 @@ None of MCR (Mirantis Container Runtime), MSR (Mirantis Secure Registry), or MKE
 
 As with all deployments, the operating system that hosts the usage of Mirantis container products may be vulnerable. Despite the information below, the host system should always be verified with the operating system vendor to ensure that it is not vulnerable. Though no additional risk is introduced through the use of the Mirantis products listed in this bulletin, taking this step will ensure that the complete deployment is secured.
 
-Mirantis Container Runtime (MCR) is shipped as operating system packages. As such, MCR itself does not contain or enable the installation of any affected versions of xz.
+Mirantis Container Runtime is shipped as operating system packages. As such, MCR itself does not contain or enable the installation of any affected versions of xz.
 
-Mirantis Secure Registry (MSR) consists of numerous components that are built on [https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html](Alpine Linux) images.  Mirantis has confirmed that this underlying Alpine image is not affected by the xz vulnerability and therefore MSR provides no vector for attack via this exploit. Customer images stored in a registry hosted by MSR could however contain this vulnerability which should be monitored and remedied using MSR security and CVE scanning features.
+Mirantis Secure Registry consists of numerous components that are built on [https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html](Alpine Linux) images.  Mirantis has confirmed that this underlying Alpine image is not affected by the xz vulnerability and therefore MSR provides no vector for attack via this exploit. Customer images stored in a registry hosted by MSR could however contain this vulnerability which should be monitored and remedied using MSR security and CVE scanning features.
 
-Mirantis Kubernetes Engine (MKE) has been verified not to include any vulnerable xz, as either part of the software (like MSR, MKE is also built on unaffected [https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html](Alpine Linux)) or as part of the build chain. Accordingly, the use of MKE does not provide any additional exposure to this xz vulnerability. Customers should additionally ensure that applications deployed using MKE are not vulnerable to secure their environment.
+Mirantis Kubernetes Engine has been verified not to include any vulnerable xz, as either part of the software (like MSR, MKE is also built on unaffected [https://www.alpinelinux.org/posts/XZ-backdoor-CVE-2024-3094.html](Alpine Linux)) or as part of the build chain. Accordingly, the use of MKE does not provide any additional exposure to this xz vulnerability. Customers should additionally ensure that applications deployed using MKE are not vulnerable to secure their environment.
 
 
-#### Vulnerability Information
+### Vulnerability Information
 
 #### CVE Identifier
 CVE-2024-3094

--- a/advisories/advisories.md
+++ b/advisories/advisories.md
@@ -1,10 +1,11 @@
 ## Security Advisories
 
+* [0012](/advisories/0012.md): Mirantis Container Products and CVE-2024-3094: Not Vulnerable
 * [0011](/advisories/0011.md): Mirantis Kubernetes Engine (MKE) and CVE-2024-21626: Understanding the Potential Impact and Mitigation
 * [0010](/advisories/0010.md): MCR: runc process.cwd and leaked fds container breakout
-* [0009](/advisories/0009.md): MCR: Encrypted overlay network with a single endpoint is unauthenticated 
+* [0009](/advisories/0009.md): MCR: Encrypted overlay network with a single endpoint is unauthenticated
 * [0008](/advisories/0008.md): MCR: Encrypted overlay network traffic may be unencrypted
-* [0007](/advisories/0007.md): MCR: Encrypted overlay network may be unauthenticated 
+* [0007](/advisories/0007.md): MCR: Encrypted overlay network may be unauthenticated
 * [0006](/advisories/0006.md): MCR: The Swarm VXLAN port may be exposed to attack due to ambiguous documentation
 * [0005](/advisories/0005.md): Improper URL Validation causes MCC Lens Extension to open external programs
 * [0004](/advisories/0004.md): Improper header sanitization in bored-agent causes escalation of privilege


### PR DESCRIPTION
Advisory 0012 covers xz vulnerability/backdoor as it relates to Mirantis container products MSR, MCR, and MKE.