### PR TITLE
Updated Copy-Fail and DrityFrag bulletins with links to mitigation HOC modules

### DIFF
--- a/advisories/0015.md
+++ b/advisories/0015.md
@@ -50,10 +50,12 @@ The following scenarios describe how an attacker might gain the initial access r
   * **Probability: Very Low.** This requires a sophisticated "chain" of two distinct vulnerabilities. Hypervisor escapes are rare and typically involve high-complexity exploits.
 
 ### Mitigations
-The permanent fix requires updating the Linux kernel to a version containing the upstream fix. Once the fix becomes available for the supported versions of Ubuntu, Mirantis will release updated host OS images via the standard channels. Customers should plan a rolling update of their clusters once these resources are available. In the meantime, Mirantis will provide a host OS configuration module to automate the application of the workaround below in large clusters.
+The permanent fix requires updating the Linux kernel to a version containing the upstream fix. Once the fix becomes available for the supported versions of Ubuntu, Mirantis will release updated host OS images via the standard channels. Customers should plan a rolling update of their clusters once these resources are available. In the meantime, Mirantis provides the [`copyfail_mitigation` host OS configuration module](https://github.com/Mirantis/mosk-hocm-contrib/tree/main/copyfail_mitigation) to automate the application of the workaround below across large clusters.
 
 ### Work arounds
-On each node, check whether **algif\_aead** is already loaded; persist the install rule; if the module is not loaded, no further immediate action is required after that; if it is loaded, unload it and reboot for a clean kernel state, or—when reboot cannot happen yet—drop the page cache and schedule a reboot during the next maintenance window. Apply this across **all cluster nodes**; for large clusters, push the changes via a configuration management system (e.g. Ansible) so every node stays consistent.
+For automated mitigation across many cluster nodes, use the [`copyfail_mitigation` host OS configuration module](https://github.com/Mirantis/mosk-hocm-contrib/tree/main/copyfail_mitigation). The module applies the steps below via a `HostOSConfiguration` custom resource and is the recommended approach for large MOSK clusters.
+
+Alternatively, on each node, check whether **algif\_aead** is already loaded; persist the install rule; if the module is not loaded, no further immediate action is required after that; if it is loaded, unload it and reboot for a clean kernel state, or—when reboot cannot happen yet—drop the page cache and schedule a reboot during the next maintenance window. Apply this across **all cluster nodes**; for large clusters, push the changes via a configuration management system (e.g. Ansible) so every node stays consistent.
 
 **Mitigation steps for all cluster nodes:**
 
@@ -110,6 +112,7 @@ lsmod | grep algif_aead
 * **2026-04-29:** CVE-2026-31431 (“Copy-Fail”) disclosed; this advisory addresses mitigation for MOSK cluster nodes.
 
 ### References
+* [copyfail\_mitigation host OS configuration module](https://github.com/Mirantis/mosk-hocm-contrib/tree/main/copyfail_mitigation)
 * [NVD \- CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431)
 * [CVE-2026-31431 | Ubuntu](https://ubuntu.com/security/CVE-2026-31431)
 * [Copy-Fail](https://copy.fail/)

--- a/advisories/0017.md
+++ b/advisories/0017.md
@@ -63,13 +63,15 @@ If an exploit for these vulnerabilities is successfully executed on a cluster co
   * **Probability: Very Low.** This requires a sophisticated “chain” of two distinct vulnerabilities. Hypervisor escapes are rare and typically involve high-complexity exploits.
 
 ### Mitigations
-The permanent fix is **installation of patched kernel modules (and/or kernel packages)** containing upstream fixes for CVE-2026-43284 and CVE-2026-43500, delivered through your supported host OS distribution channels. **Mirantis will publish updated host OS images** via standard channels once fixes are available for supported releases; customers should plan rolling updates of their clusters accordingly.
+The permanent fix is **installation of patched kernel modules (and/or kernel packages)** containing upstream fixes for CVE-2026-43284 and CVE-2026-43500, delivered through your supported host OS distribution channels. **Mirantis will publish updated host OS images** via standard channels once fixes are available for supported releases; customers should plan rolling updates of their clusters accordingly. In the meantime, Mirantis provides the [`dirtyfrag_mitigation` host OS configuration module](https://github.com/Mirantis/mosk-hocm-contrib/tree/main/dirtyfrag_mitigation) to automate the application of the workaround below across large clusters.
 
 Mirantis has confirmed that **[encryption of cloud control plane communications](https://docs.mirantis.com/mosk/26.1/security/data-protection/control-plane-communications.html)** (WireGuard on the Calico underlay) does **not** require `esp4` / `esp6`. For **Neutron IPsec** features (East–West tenant traffic encryption, VPN aaS), retaining functionality without disabling ESP until patched modules are available remains under evaluation; see workaround **(c)**.
 
 ### Work arounds
 
-Apply the following consistently across nodes (use configuration management at scale). Combine module install rules in a single file if preferred.
+For automated mitigation across many cluster nodes, use the [`dirtyfrag_mitigation` host OS configuration module](https://github.com/Mirantis/mosk-hocm-contrib/tree/main/dirtyfrag_mitigation). The module applies the steps below via a `HostOSConfiguration` custom resource and is the recommended approach for large MOSK clusters. Set `skipDisablingEspModules: true` when Neutron IPsec-based features are enabled and `esp4` / `esp6` must remain loaded until those features are disabled (see workaround **(c)**).
+
+Alternatively, apply the following consistently across nodes (use configuration management at scale). Combine module install rules in a single file if preferred.
 
 #### (a) All nodes, all clusters: disable RxRPC
 
@@ -204,6 +206,7 @@ The `grep` commands should return no output when modules are not loaded.
 * **2026-05-07:** “Dirty Frag” discussed publicly; CVE-2026-43284 (ESP/xfrm) and CVE-2026-43500 (RxRPC) assigned; this advisory addresses impact and mitigation for MOSK cluster nodes.
 
 ### References
+* [dirtyfrag\_mitigation host OS configuration module](https://github.com/Mirantis/mosk-hocm-contrib/tree/main/dirtyfrag_mitigation)
 * [NVD — CVE-2026-43284](https://nvd.nist.gov/vuln/detail/CVE-2026-43284)
 * [NVD — CVE-2026-43500](https://nvd.nist.gov/vuln/detail/CVE-2026-43500)
 * Related MOSK bulletin: [0015 — Copy-Fail (CVE-2026-31431)](/advisories/0015.md)


### PR DESCRIPTION
- **Update Copy-Fail advisory to include automated mitigation module and clarify manual workaround steps for large clusters**
- **Enhance Dirty Frag advisory with automated mitigation module details and clarify manual workaround instructions for large clusters**
